### PR TITLE
Introduce projection retries and management

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -53,6 +53,8 @@ lazy val aggregatedProjects: Seq[ProjectReference] =
     core,
     doobie,
     memory,
+    projection,
+    doobieProjection,
   )
 
 inThisBuild(replSettings)
@@ -115,7 +117,39 @@ lazy val memory = (project in file("memory"))
       cats,
       `zio-test`,
       `zio-test-sbt`,
+    `zio-test-magnolia`,
+  ),
+)
+
+lazy val projection = (project in file("projection"))
+  .dependsOn(memory % "compile->compile;test->test")
+  .settings(stdSettings("projection"))
+  .settings(
+    testFrameworks += new TestFramework("zio.test.sbt.ZTestFramework"),
+    Test / unmanagedResourceDirectories ++= (Compile / unmanagedResourceDirectories).value,
+    libraryDependencies ++= Seq(
+      cats,
+      `zio-test`,
+      `zio-test-sbt`,
       `zio-test-magnolia`,
+    ),
+  )
+
+lazy val doobieProjection = (project in file("doobie-projection"))
+  .dependsOn(core % "compile->compile;test->test", projection % "compile->compile;test->test")
+  .settings(stdSettings("doobie-projection"))
+  .settings(
+    testFrameworks += new TestFramework("zio.test.sbt.ZTestFramework"),
+    Test / unmanagedResourceDirectories ++= (Compile / unmanagedResourceDirectories).value,
+    libraryDependencies ++= db,
+    libraryDependencies ++= Seq(
+      cats,
+      `zio-interop-cats`,
+      mockito,
+      `zio-test`,
+      `zio-test-sbt`,
+      `zio-test-magnolia`,
+      `zio-mock`,
     ),
   )
 

--- a/doobie-projection/src/main/resources/schema.sql
+++ b/doobie-projection/src/main/resources/schema.sql
@@ -10,7 +10,7 @@ CREATE TABLE IF NOT EXISTS projection_management (
   name TEXT NOT NULL,
   version TEXT NOT NULL,
   namespace INT NOT NULL,
-  paused BOOLEAN NOT NULL,
+  stopped BOOLEAN NOT NULL,
   PRIMARY KEY(name, version, namespace)
 );
 

--- a/doobie-projection/src/main/resources/schema.sql
+++ b/doobie-projection/src/main/resources/schema.sql
@@ -1,0 +1,19 @@
+CREATE TABLE IF NOT EXISTS projection_offset (
+  name TEXT NOT NULL,
+  version TEXT NOT NULL,
+  namespace INT NOT NULL,
+  offset BIGINT NOT NULL,
+  PRIMARY KEY(name, version, namespace)
+);
+
+CREATE TABLE IF NOT EXISTS projection_management (
+  name TEXT NOT NULL,
+  version TEXT NOT NULL,
+  namespace INT NOT NULL,
+  paused BOOLEAN NOT NULL,
+  PRIMARY KEY(name, version, namespace)
+);
+
+CREATE INDEX IF NOT EXISTS idx_projection_offset_namespace ON projection_offset(namespace);
+CREATE INDEX IF NOT EXISTS idx_projection_management_namespace ON projection_management(namespace);
+

--- a/doobie-projection/src/main/scala/com/github/aris/projection/postgres/JdbcCodecs.scala
+++ b/doobie-projection/src/main/scala/com/github/aris/projection/postgres/JdbcCodecs.scala
@@ -1,0 +1,75 @@
+package com.github
+package aris
+package projection
+package postgres
+
+import cats.implicits.*
+
+import zio.schema.*
+import zio.schema.codec.*
+
+import zio.*
+import zio.prelude.*
+
+import doobie.*
+import doobie.implicits.*
+
+trait JdbcCodecs {
+  def toJson[A: Schema](value: A): String =
+    JsonCodec.schemaBasedBinaryCodec(Schema[A]).encode(value).asString
+
+  given Meta[Version] = Meta[Long].timap(Version.wrap)(Version.unwrap)
+  given Meta[Timestamp] = Meta[Long].timap(Timestamp.wrap)(Timestamp.unwrap)
+  given Meta[Key] = Meta[Long].timap(Key.wrap)(Key.unwrap)
+  given Meta[Namespace] = Meta[Int].timap(Namespace.wrap)(Namespace.unwrap)
+  given Meta[Discriminator] = Meta[String].timap(Discriminator.wrap)(Discriminator.unwrap)
+  given Meta[EventTag] = Meta[String].timap(EventTag.wrap)(EventTag.unwrap)
+
+  inline def byteArrayReader[Event: BinaryCodec]: Read[Event] =
+    Read[Array[Byte]].map { case (bytes) =>
+      summon[BinaryCodec[Event]].decode(Chunk(bytes*)) match {
+        case Left(error) => throw new Exception(s"Failed to decode bytes into Event: $error")
+        case Right(value) => value
+      }
+    }
+
+  extension (t: TimeInterval)
+    def toSql: Fragment =
+      fr"timestamp >= ${t.start} AND timestamp < ${t.end}"
+
+  extension (o: FetchOptions)
+    def toSql: (Option[Fragment], Option[Fragment], Fragment) =
+      val offsetQuery = o.offset.map(offset =>
+        o.order match {
+          case FetchOptions.Order.asc => fr"version > $offset"
+          case FetchOptions.Order.desc => fr"version < $offset"
+        },
+      )
+      val limitQuery = o.limit.map(limit => fr"LIMIT $limit")
+      val orderQuery = o.order match {
+        case FetchOptions.Order.asc => fr"ORDER BY version ASC"
+        case FetchOptions.Order.desc => fr"ORDER BY version DESC"
+      }
+      (offsetQuery, limitQuery, orderQuery)
+
+  extension (o: NonEmptyList[Namespace])
+    @scala.annotation.targetName("toSql_NonEmptyList_Namespace")
+    def toSql: Fragment = o match {
+      case NonEmptyList.Single(n) => n.toSql
+      case NonEmptyList.Cons(n, ns) =>
+        fr0"namespace IN (" ++ (n :: ns).toList.map(n => fr0"$n").intercalate(fr",") ++ fr")"
+    }
+
+  extension (o: Namespace)
+    @scala.annotation.targetName("toSql_Namespace")
+    def toSql: Fragment = o match {
+      case n => fr"namespace = $n"
+    }
+
+  extension (t: EventTag)
+    @scala.annotation.targetName("toSql_EventTag")
+    def toSql: Fragment = fr"t.tag = $t"
+
+  extension (f: Fragment) inline def isEmpty: Boolean = f.internals.elements.isEmpty
+
+}

--- a/doobie-projection/src/main/scala/com/github/aris/projection/postgres/PostgresProjectionManagementStore.scala
+++ b/doobie-projection/src/main/scala/com/github/aris/projection/postgres/PostgresProjectionManagementStore.scala
@@ -1,0 +1,57 @@
+package com.github
+package aris
+package projection
+package postgres
+
+import com.github.aris.projection.{ProjectionManagementStore, Projection}
+import com.github.aris.Version
+import zio.*
+import doobie.*
+import doobie.implicits.*
+
+trait PostgresProjectionManagementStore extends ProjectionManagementStore
+
+object PostgresProjectionManagementStore {
+  def live(xa: Transactor[Task]): ZLayer[Any, Nothing, ProjectionManagementStore] =
+    ZLayer.succeed(new PostgresProjectionManagementStoreLive(xa))
+
+  class PostgresProjectionManagementStoreLive(xa: Transactor[Task]) extends PostgresProjectionManagementStore with JdbcCodecs {
+    def pause(id: Projection.Id): Task[Unit] =
+      Queries.PAUSE(id).run.transact(xa).unit
+
+    def resume(id: Projection.Id): Task[Unit] =
+      Queries.RESUME(id).run.transact(xa).unit
+
+    def isPaused(id: Projection.Id): Task[Boolean] =
+      Queries.IS_PAUSED(id).option.transact(xa).map(_.getOrElse(false))
+
+    def offset(id: Projection.Id): Task[Option[Version]] =
+      Queries.READ_OFFSET(id).option.transact(xa)
+
+    def updateOffset(id: Projection.Id, version: Version): Task[Unit] =
+      Queries.UPDATE_OFFSET(id, version).run.transact(xa).unit
+  }
+
+  object Queries extends JdbcCodecs {
+    def PAUSE(id: Projection.Id): Update0 =
+      sql"""INSERT INTO projections (name, version, offset, paused)
+             VALUES (${id.name}, ${id.version}, 0, true)
+             ON CONFLICT (name, version) DO UPDATE SET paused = true""".update
+
+    def RESUME(id: Projection.Id): Update0 =
+      sql"""INSERT INTO projections (name, version, offset, paused)
+             VALUES (${id.name}, ${id.version}, 0, false)
+             ON CONFLICT (name, version) DO UPDATE SET paused = false""".update
+
+    def IS_PAUSED(id: Projection.Id): Query0[Boolean] =
+      sql"""SELECT paused FROM projections WHERE name = ${id.name} AND version = ${id.version}""".query[Boolean]
+
+    def READ_OFFSET(id: Projection.Id): Query0[Version] =
+      sql"""SELECT offset FROM projections WHERE name = ${id.name} AND version = ${id.version}""".query[Version]
+
+    def UPDATE_OFFSET(id: Projection.Id, version: Version): Update0 =
+      sql"""INSERT INTO projections (name, version, offset, paused)
+             VALUES (${id.name}, ${id.version}, $version, false)
+             ON CONFLICT (name, version) DO UPDATE SET offset = $version""".update
+  }
+}

--- a/doobie-projection/src/main/scala/com/github/aris/projection/postgres/PostgresProjectionManagementStore.scala
+++ b/doobie-projection/src/main/scala/com/github/aris/projection/postgres/PostgresProjectionManagementStore.scala
@@ -34,24 +34,24 @@ object PostgresProjectionManagementStore {
 
   object Queries extends JdbcCodecs {
     def PAUSE(id: Projection.Id): Update0 =
-      sql"""INSERT INTO projections (name, version, offset, paused)
-             VALUES (${id.name}, ${id.version}, 0, true)
-             ON CONFLICT (name, version) DO UPDATE SET paused = true""".update
+      sql"""INSERT INTO projection_management (name, version, namespace, paused)
+             VALUES (${id.name}, ${id.version}, ${id.namespace}, true)
+             ON CONFLICT (name, version, namespace) DO UPDATE SET paused = true""".update
 
     def RESUME(id: Projection.Id): Update0 =
-      sql"""INSERT INTO projections (name, version, offset, paused)
-             VALUES (${id.name}, ${id.version}, 0, false)
-             ON CONFLICT (name, version) DO UPDATE SET paused = false""".update
+      sql"""INSERT INTO projection_management (name, version, namespace, paused)
+             VALUES (${id.name}, ${id.version}, ${id.namespace}, false)
+             ON CONFLICT (name, version, namespace) DO UPDATE SET paused = false""".update
 
     def IS_PAUSED(id: Projection.Id): Query0[Boolean] =
-      sql"""SELECT paused FROM projections WHERE name = ${id.name} AND version = ${id.version}""".query[Boolean]
+      sql"""SELECT paused FROM projection_management WHERE name = ${id.name} AND version = ${id.version} AND namespace = ${id.namespace}""".query[Boolean]
 
     def READ_OFFSET(id: Projection.Id): Query0[Version] =
-      sql"""SELECT offset FROM projections WHERE name = ${id.name} AND version = ${id.version}""".query[Version]
+      sql"""SELECT offset FROM projection_offset WHERE name = ${id.name} AND version = ${id.version} AND namespace = ${id.namespace}""".query[Version]
 
     def UPDATE_OFFSET(id: Projection.Id, version: Version): Update0 =
-      sql"""INSERT INTO projections (name, version, offset, paused)
-             VALUES (${id.name}, ${id.version}, $version, false)
-             ON CONFLICT (name, version) DO UPDATE SET offset = $version""".update
+      sql"""INSERT INTO projection_offset (name, version, namespace, offset)
+             VALUES (${id.name}, ${id.version}, ${id.namespace}, $version)
+             ON CONFLICT (name, version, namespace) DO UPDATE SET offset = $version""".update
   }
 }

--- a/doobie-projection/src/main/scala/com/github/aris/projection/postgres/PostgresProjectionManagementStore.scala
+++ b/doobie-projection/src/main/scala/com/github/aris/projection/postgres/PostgresProjectionManagementStore.scala
@@ -16,14 +16,14 @@ object PostgresProjectionManagementStore {
     ZLayer.succeed(new PostgresProjectionManagementStoreLive(xa))
 
   class PostgresProjectionManagementStoreLive(xa: Transactor[Task]) extends PostgresProjectionManagementStore with JdbcCodecs {
-    def pause(id: Projection.Id): Task[Unit] =
-      Queries.PAUSE(id).run.transact(xa).unit
+    def stop(id: Projection.Id): Task[Unit] =
+      Queries.STOP(id).run.transact(xa).unit
 
     def resume(id: Projection.Id): Task[Unit] =
       Queries.RESUME(id).run.transact(xa).unit
 
-    def isPaused(id: Projection.Id): Task[Boolean] =
-      Queries.IS_PAUSED(id).option.transact(xa).map(_.getOrElse(false))
+    def isStopped(id: Projection.Id): Task[Boolean] =
+      Queries.IS_STOPPED(id).option.transact(xa).map(_.getOrElse(false))
 
     def offset(id: Projection.Id): Task[Option[Version]] =
       Queries.READ_OFFSET(id).option.transact(xa)
@@ -33,18 +33,18 @@ object PostgresProjectionManagementStore {
   }
 
   object Queries extends JdbcCodecs {
-    def PAUSE(id: Projection.Id): Update0 =
-      sql"""INSERT INTO projection_management (name, version, namespace, paused)
+    def STOP(id: Projection.Id): Update0 =
+      sql"""INSERT INTO projection_management (name, version, namespace, stopped)
              VALUES (${id.name}, ${id.version}, ${id.namespace}, true)
-             ON CONFLICT (name, version, namespace) DO UPDATE SET paused = true""".update
+             ON CONFLICT (name, version, namespace) DO UPDATE SET stopped = true""".update
 
     def RESUME(id: Projection.Id): Update0 =
-      sql"""INSERT INTO projection_management (name, version, namespace, paused)
+      sql"""INSERT INTO projection_management (name, version, namespace, stopped)
              VALUES (${id.name}, ${id.version}, ${id.namespace}, false)
-             ON CONFLICT (name, version, namespace) DO UPDATE SET paused = false""".update
+             ON CONFLICT (name, version, namespace) DO UPDATE SET stopped = false""".update
 
-    def IS_PAUSED(id: Projection.Id): Query0[Boolean] =
-      sql"""SELECT paused FROM projection_management WHERE name = ${id.name} AND version = ${id.version} AND namespace = ${id.namespace}""".query[Boolean]
+    def IS_STOPPED(id: Projection.Id): Query0[Boolean] =
+      sql"""SELECT stopped FROM projection_management WHERE name = ${id.name} AND version = ${id.version} AND namespace = ${id.namespace}""".query[Boolean]
 
     def READ_OFFSET(id: Projection.Id): Query0[Version] =
       sql"""SELECT offset FROM projection_offset WHERE name = ${id.name} AND version = ${id.version} AND namespace = ${id.namespace}""".query[Version]

--- a/doobie-projection/src/main/scala/com/github/aris/projection/postgres/PostgresProjectionStore.scala
+++ b/doobie-projection/src/main/scala/com/github/aris/projection/postgres/PostgresProjectionStore.scala
@@ -25,11 +25,11 @@ object PostgresProjectionStore {
 
   object Queries extends JdbcCodecs {
     def READ(id: Projection.Id): Query0[Version] =
-      sql"""SELECT offset FROM projections WHERE name = ${id.name} AND version = ${id.version}""".query[Version]
+      sql"""SELECT offset FROM projection_offset WHERE name = ${id.name} AND version = ${id.version} AND namespace = ${id.namespace}""".query[Version]
 
     def SAVE(id: Projection.Id, version: Version): Update0 =
-      sql"""INSERT INTO projections (name, version, offset, paused)
-             VALUES (${id.name}, ${id.version}, $version, false)
-             ON CONFLICT (name, version) DO UPDATE SET offset = $version""".update
+      sql"""INSERT INTO projection_offset (name, version, namespace, offset)
+             VALUES (${id.name}, ${id.version}, ${id.namespace}, $version)
+             ON CONFLICT (name, version, namespace) DO UPDATE SET offset = $version""".update
   }
 }

--- a/doobie-projection/src/main/scala/com/github/aris/projection/postgres/PostgresProjectionStore.scala
+++ b/doobie-projection/src/main/scala/com/github/aris/projection/postgres/PostgresProjectionStore.scala
@@ -1,0 +1,35 @@
+package com.github
+package aris
+package projection
+package postgres
+
+import com.github.aris.projection.{ProjectionStore, Projection}
+import com.github.aris.{Version}
+import zio.*
+import doobie.*
+import doobie.implicits.*
+
+trait PostgresProjectionStore extends ProjectionStore
+
+object PostgresProjectionStore {
+  def live(xa: Transactor[Task]): ZLayer[Any, Nothing, ProjectionStore] =
+    ZLayer.succeed(new PostgresProjectionStoreLive(xa))
+
+  class PostgresProjectionStoreLive(xa: Transactor[Task]) extends PostgresProjectionStore with JdbcCodecs {
+    def read(id: Projection.Id): Task[Option[Version]] =
+      Queries.READ(id).option.transact(xa)
+
+    def save(id: Projection.Id, version: Version): Task[Int] =
+      Queries.SAVE(id, version).run.transact(xa).map(_.toInt)
+  }
+
+  object Queries extends JdbcCodecs {
+    def READ(id: Projection.Id): Query0[Version] =
+      sql"""SELECT offset FROM projections WHERE name = ${id.name} AND version = ${id.version}""".query[Version]
+
+    def SAVE(id: Projection.Id, version: Version): Update0 =
+      sql"""INSERT INTO projections (name, version, offset, paused)
+             VALUES (${id.name}, ${id.version}, $version, false)
+             ON CONFLICT (name, version) DO UPDATE SET offset = $version""".update
+  }
+}

--- a/doobie/src/main/resources/schema.sql
+++ b/doobie/src/main/resources/schema.sql
@@ -1,0 +1,29 @@
+CREATE TABLE IF NOT EXISTS events (
+  version BIGINT PRIMARY KEY,
+  aggregate_id BIGINT NOT NULL,
+  discriminator TEXT NOT NULL,
+  namespace INT NOT NULL,
+  payload BYTEA NOT NULL,
+  timestamp BIGINT NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_events_discriminator ON events(discriminator);
+CREATE INDEX IF NOT EXISTS idx_events_aggregate_id ON events(aggregate_id);
+CREATE INDEX IF NOT EXISTS idx_events_discriminator_namespace ON events(discriminator, namespace);
+CREATE INDEX IF NOT EXISTS idx_events_aggregate_disc_ns ON events(aggregate_id, discriminator, namespace);
+CREATE INDEX IF NOT EXISTS idx_events_timestamp ON events(timestamp);
+
+CREATE TABLE IF NOT EXISTS tags (
+  version BIGINT NOT NULL,
+  tag TEXT NOT NULL,
+  PRIMARY KEY(version, tag),
+  FOREIGN KEY(version) REFERENCES events(version) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS idx_tags_tag ON tags(tag);
+
+CREATE TABLE IF NOT EXISTS snapshots (
+  aggregate_id BIGINT PRIMARY KEY,
+  version BIGINT NOT NULL
+);
+

--- a/projection/src/main/scala/com/github/aris/projection/Envelope.scala
+++ b/projection/src/main/scala/com/github/aris/projection/Envelope.scala
@@ -1,0 +1,13 @@
+package com.github
+package aris
+package projection
+
+import com.github.aris.domain.*
+
+case class Envelope[T](
+  version: Version,
+  event: T,
+  namespace: Namespace,
+  discriminator: Discriminator,
+  key: Key,
+)

--- a/projection/src/main/scala/com/github/aris/projection/Projection.scala
+++ b/projection/src/main/scala/com/github/aris/projection/Projection.scala
@@ -74,7 +74,6 @@ private[aris] final case class ExactlyOnce[Event](
                    handleWithRetry(env) *> commit(env.version)
                  }
                  .tapError(e => observer.projectionError(id, e))
-                 .catchAll(_ => ZIO.unit)
     } yield ()
 
   private def commit(v: Version): UIO[Unit] =
@@ -126,7 +125,6 @@ private[aris] final case class AtLeastOnce[Event](
                    handleWithRetry(env) *> maybeCommit(env.version, ref)
                  }
                  .tapError(e => observer.projectionError(id, e))
-                 .catchAll(_ => ZIO.unit)
     } yield ()
 
   private def commit(v: Version): UIO[Unit] =

--- a/projection/src/main/scala/com/github/aris/projection/Projection.scala
+++ b/projection/src/main/scala/com/github/aris/projection/Projection.scala
@@ -25,7 +25,7 @@ object Projection {
     extension (v: VersionId) inline def value: String = unwrap(v)
   }
 
-  final case class Id(name: Name, version: VersionId)
+  final case class Id(name: Name, version: VersionId, namespace: Namespace)
 
   def exactlyOnce[Event](
     id: Id,

--- a/projection/src/main/scala/com/github/aris/projection/Projection.scala
+++ b/projection/src/main/scala/com/github/aris/projection/Projection.scala
@@ -1,0 +1,166 @@
+package com.github
+package aris
+package projection
+
+import com.github.aris.domain.*
+
+import zio.*
+import zio.stream.*
+import zio.prelude.*
+
+trait Projection {
+  def run: ZIO[Scope, Nothing, Unit]
+}
+
+object Projection {
+  import zio.prelude.*
+
+  type Name = Name.Type
+  object Name extends Newtype[String] {
+    extension (n: Name) inline def value: String = unwrap(n)
+  }
+
+  type VersionId = VersionId.Type
+  object VersionId extends Newtype[String] {
+    extension (v: VersionId) inline def value: String = unwrap(v)
+  }
+
+  final case class Id(name: Name, version: VersionId)
+
+  def exactlyOnce[Event](
+    id: Id,
+    handler: Envelope[Event] => Task[Unit],
+    query: Version => ZStream[Any, Throwable, Envelope[Event]],
+    store: ProjectionManagementStore,
+    observer: ProjectionObserver = ProjectionObserver.empty,
+    retry: RetryStrategy = RetryStrategy.Skip,
+  ): Projection =
+    ExactlyOnce(id, handler, query, store, observer, retry)
+
+  def atLeastOnce[Event](
+    id: Id,
+    handler: Envelope[Event] => Task[Unit],
+    query: Version => ZStream[Any, Throwable, Envelope[Event]],
+    store: ProjectionManagementStore,
+    commitAfterN: Int,
+    commitAfter: Duration,
+    observer: ProjectionObserver = ProjectionObserver.empty,
+    retry: RetryStrategy = RetryStrategy.Skip,
+  ): Projection =
+    AtLeastOnce(id, handler, query, store, commitAfterN, commitAfter, observer, retry)
+}
+
+private[aris] final case class ExactlyOnce[Event](
+  id: Projection.Id,
+  handler: Envelope[Event] => Task[Unit],
+  query: Version => ZStream[Any, Throwable, Envelope[Event]],
+  store: ProjectionManagementStore,
+  observer: ProjectionObserver = ProjectionObserver.empty,
+  retry: RetryStrategy = RetryStrategy.Skip,
+) extends Projection {
+
+  def run: ZIO[Scope, Nothing, Unit] =
+    store.isPaused(id).flatMap { paused =>
+      if paused then ZIO.unit
+      else process
+    }.orDie
+
+  private def process: ZIO[Scope, Nothing, Unit] =
+    for {
+      start <- store.offset(id).map(_.getOrElse(Version.wrap(0L))).orDie
+      _     <- observer.started(id, start)
+      _     <- query(start)
+                 .foreach { env =>
+                   handleWithRetry(env) *> commit(env.version)
+                 }
+                 .tapError(e => observer.projectionError(id, e))
+                 .catchAll(_ => ZIO.unit)
+    } yield ()
+
+  private def commit(v: Version): UIO[Unit] =
+    store.updateOffset(id, v).catchAll(e => observer.projectionError(id, e)) *> observer.offsetCommitted(id, v)
+
+  private def handleWithRetry(env: Envelope[Event]): ZIO[Any, Nothing, Unit] =
+    def loop(left: Int): ZIO[Any, Nothing, Unit] =
+      handler(env).catchAll { e =>
+        observer.processingError(id, env.version, e) *>
+          (retry match
+            case RetryStrategy.Skip                      => ZIO.unit
+            case RetryStrategy.RetryAndFail(n) if left > 0  => loop(left - 1)
+            case RetryStrategy.RetryAndFail(_)              => ZIO.unit
+            case RetryStrategy.RetryAndSkip(n) if left > 0  => loop(left - 1)
+            case RetryStrategy.RetryAndSkip(_)              => ZIO.unit
+          )
+      }
+
+    retry match
+      case RetryStrategy.Skip            => loop(0)
+      case RetryStrategy.RetryAndFail(n) => loop(n)
+      case RetryStrategy.RetryAndSkip(n) => loop(n)
+}
+
+private[aris] final case class AtLeastOnce[Event](
+  id: Projection.Id,
+  handler: Envelope[Event] => Task[Unit],
+  query: Version => ZStream[Any, Throwable, Envelope[Event]],
+  store: ProjectionManagementStore,
+  commitAfterN: Int,
+  commitAfter: Duration,
+  observer: ProjectionObserver = ProjectionObserver.empty,
+  retry: RetryStrategy = RetryStrategy.Skip,
+) extends Projection {
+
+  def run: ZIO[Scope, Nothing, Unit] =
+    store.isPaused(id).flatMap { paused =>
+      if paused then ZIO.unit
+      else process
+    }.orDie
+
+  private def process: ZIO[Scope, Nothing, Unit] =
+    for {
+      start <- store.offset(id).map(_.getOrElse(Version.wrap(0L))).orDie
+      _     <- observer.started(id, start)
+      ref   <- Ref.make((start, 0, 0L))
+      _     <- query(start)
+                 .foreach { env =>
+                   handleWithRetry(env) *> maybeCommit(env.version, ref)
+                 }
+                 .tapError(e => observer.projectionError(id, e))
+                 .catchAll(_ => ZIO.unit)
+    } yield ()
+
+  private def commit(v: Version): UIO[Unit] =
+    store.updateOffset(id, v).catchAll(e => observer.projectionError(id, e)) *> observer.offsetCommitted(id, v)
+
+  private def maybeCommit(v: Version, ref: Ref[(Version, Int, Long)]): UIO[Unit] =
+    for {
+      now    <- Clock.nanoTime
+      shouldSave <- ref.modify { case (_, count, ts) =>
+                   val newCount   = count + 1
+                   val elapsed    = Duration.fromNanos(now - ts)
+                   val shouldSave = newCount >= commitAfterN || elapsed >= commitAfter
+                   val nextTs     = if shouldSave then now else ts
+                   val next       = if shouldSave then (v, 0, nextTs) else (v, newCount, ts)
+                   (shouldSave, next)
+                 }
+      _ <- ZIO.when(shouldSave)(commit(v))
+    } yield ()
+
+  private def handleWithRetry(env: Envelope[Event]): ZIO[Any, Nothing, Unit] =
+    def loop(left: Int): ZIO[Any, Nothing, Unit] =
+      handler(env).catchAll { e =>
+        observer.processingError(id, env.version, e) *>
+          (retry match
+            case RetryStrategy.Skip                      => ZIO.unit
+            case RetryStrategy.RetryAndFail(n) if left > 0  => loop(left - 1)
+            case RetryStrategy.RetryAndFail(_)              => ZIO.unit
+            case RetryStrategy.RetryAndSkip(n) if left > 0  => loop(left - 1)
+            case RetryStrategy.RetryAndSkip(_)              => ZIO.unit
+          )
+      }
+
+    retry match
+      case RetryStrategy.Skip            => loop(0)
+      case RetryStrategy.RetryAndFail(n) => loop(n)
+      case RetryStrategy.RetryAndSkip(n) => loop(n)
+}

--- a/projection/src/main/scala/com/github/aris/projection/ProjectionManagement.scala
+++ b/projection/src/main/scala/com/github/aris/projection/ProjectionManagement.scala
@@ -10,11 +10,11 @@ final class ProjectionManagement(
   observer: ProjectionManagementObserver = ProjectionManagementObserver.empty,
 ) {
 
-  def pause(): UIO[Unit] =
+  def stop(): UIO[Unit] =
     for {
       off <- store.offset(id).map(_.getOrElse(Version.wrap(0L))).orDie
-      _   <- observer.paused(id, off)
-      _   <- store.pause(id).orDie
+      _   <- observer.stopped(id, off)
+      _   <- store.stop(id).orDie
     } yield ()
 
   def resume(): UIO[Unit] =
@@ -24,7 +24,7 @@ final class ProjectionManagement(
       _   <- observer.resumed(id, off)
     } yield ()
 
-  def isPaused: Task[Boolean] = store.isPaused(id)
+  def isStopped: Task[Boolean] = store.isStopped(id)
   def updateOffset(v: Version): Task[Unit] = store.updateOffset(id, v)
   def offset: Task[Option[Version]] = store.offset(id)
 }

--- a/projection/src/main/scala/com/github/aris/projection/ProjectionManagement.scala
+++ b/projection/src/main/scala/com/github/aris/projection/ProjectionManagement.scala
@@ -1,0 +1,44 @@
+package com.github
+package aris
+package projection
+
+import zio.*
+
+final class ProjectionManagement(
+  val id: Projection.Id,
+  projection: Projection,
+  store: ProjectionManagementStore,
+  observer: ProjectionObserver = ProjectionObserver.empty,
+) {
+  private val fiberRef =
+    Unsafe.unsafe { implicit u =>
+      Runtime.default.unsafe
+        .run(Ref.make[Option[Fiber.Runtime[Throwable, Unit]]](None))
+        .getOrThrowFiberFailure()
+    }
+
+  def pause(): UIO[Unit] =
+    for {
+      fiberOpt <- fiberRef.getAndSet(None)
+      _        <- ZIO.foreachDiscard(fiberOpt)(_.interrupt)
+      off      <- store.offset(id).map(_.getOrElse(Version.wrap(0L))).orDie
+      _        <- observer.paused(id, off)
+      _        <- store.pause(id).orDie
+    } yield ()
+
+  def resume(): ZIO[Scope, Nothing, Unit] =
+    ZIO.acquireRelease(
+      for {
+        _     <- pause()
+        off   <- store.offset(id).map(_.getOrElse(Version.wrap(0L))).orDie
+        _     <- store.resume(id).orDie
+        _     <- observer.resumed(id, off)
+        fiber <- projection.run.forkScoped
+        _     <- fiberRef.set(Some(fiber))
+      } yield ()
+    )(_ => pause()).unit
+
+  def isPaused: Task[Boolean] = store.isPaused(id)
+  def updateOffset(v: Version): Task[Unit] = store.updateOffset(id, v)
+  def offset: Task[Option[Version]] = store.offset(id)
+}

--- a/projection/src/main/scala/com/github/aris/projection/ProjectionManagement.scala
+++ b/projection/src/main/scala/com/github/aris/projection/ProjectionManagement.scala
@@ -6,37 +6,23 @@ import zio.*
 
 final class ProjectionManagement(
   val id: Projection.Id,
-  projection: Projection,
   store: ProjectionManagementStore,
-  observer: ProjectionObserver = ProjectionObserver.empty,
+  observer: ProjectionManagementObserver = ProjectionManagementObserver.empty,
 ) {
-  private val fiberRef =
-    Unsafe.unsafe { implicit u =>
-      Runtime.default.unsafe
-        .run(Ref.make[Option[Fiber.Runtime[Throwable, Unit]]](None))
-        .getOrThrowFiberFailure()
-    }
 
   def pause(): UIO[Unit] =
     for {
-      fiberOpt <- fiberRef.getAndSet(None)
-      _        <- ZIO.foreachDiscard(fiberOpt)(_.interrupt)
-      off      <- store.offset(id).map(_.getOrElse(Version.wrap(0L))).orDie
-      _        <- observer.paused(id, off)
-      _        <- store.pause(id).orDie
+      off <- store.offset(id).map(_.getOrElse(Version.wrap(0L))).orDie
+      _   <- observer.paused(id, off)
+      _   <- store.pause(id).orDie
     } yield ()
 
-  def resume(): ZIO[Scope, Nothing, Unit] =
-    ZIO.acquireRelease(
-      for {
-        _     <- pause()
-        off   <- store.offset(id).map(_.getOrElse(Version.wrap(0L))).orDie
-        _     <- store.resume(id).orDie
-        _     <- observer.resumed(id, off)
-        fiber <- projection.run.forkScoped
-        _     <- fiberRef.set(Some(fiber))
-      } yield ()
-    )(_ => pause()).unit
+  def resume(): UIO[Unit] =
+    for {
+      off <- store.offset(id).map(_.getOrElse(Version.wrap(0L))).orDie
+      _   <- store.resume(id).orDie
+      _   <- observer.resumed(id, off)
+    } yield ()
 
   def isPaused: Task[Boolean] = store.isPaused(id)
   def updateOffset(v: Version): Task[Unit] = store.updateOffset(id, v)

--- a/projection/src/main/scala/com/github/aris/projection/ProjectionManagementObserver.scala
+++ b/projection/src/main/scala/com/github/aris/projection/ProjectionManagementObserver.scala
@@ -1,0 +1,15 @@
+package com.github
+package aris
+package projection
+
+import zio.*
+
+trait ProjectionManagementObserver {
+  def paused(id: Projection.Id, offset: Version): UIO[Unit] = ZIO.unit
+  def resumed(id: Projection.Id, offset: Version): UIO[Unit] = ZIO.unit
+}
+
+object ProjectionManagementObserver {
+  val empty: ProjectionManagementObserver = new ProjectionManagementObserver {}
+}
+

--- a/projection/src/main/scala/com/github/aris/projection/ProjectionManagementObserver.scala
+++ b/projection/src/main/scala/com/github/aris/projection/ProjectionManagementObserver.scala
@@ -5,7 +5,7 @@ package projection
 import zio.*
 
 trait ProjectionManagementObserver {
-  def paused(id: Projection.Id, offset: Version): UIO[Unit] = ZIO.unit
+  def stopped(id: Projection.Id, offset: Version): UIO[Unit] = ZIO.unit
   def resumed(id: Projection.Id, offset: Version): UIO[Unit] = ZIO.unit
 }
 

--- a/projection/src/main/scala/com/github/aris/projection/ProjectionManagementStore.scala
+++ b/projection/src/main/scala/com/github/aris/projection/ProjectionManagementStore.scala
@@ -5,31 +5,31 @@ package projection
 import zio.*
 
 trait ProjectionManagementStore {
-  def pause(id: Projection.Id): Task[Unit]
+  def stop(id: Projection.Id): Task[Unit]
   def resume(id: Projection.Id): Task[Unit]
-  def isPaused(id: Projection.Id): Task[Boolean]
+  def isStopped(id: Projection.Id): Task[Boolean]
   def offset(id: Projection.Id): Task[Option[Version]]
   def updateOffset(id: Projection.Id, version: Version): Task[Unit]
 }
 
 object ProjectionManagementStore {
-  final case class State(offset: Version, paused: Boolean)
+  final case class State(offset: Version, stopped: Boolean)
 
   object memory {
     def live(): ZLayer[Any, Nothing, ProjectionManagementStore] =
       ZLayer.fromZIO(Ref.make(Map.empty[Projection.Id, State]).map(new MemoryProjectionManagementStore(_)))
 
     class MemoryProjectionManagementStore(ref: Ref[Map[Projection.Id, State]]) extends ProjectionManagementStore {
-      private val defaultState = State(Version.wrap(0L), paused = false)
+      private val defaultState = State(Version.wrap(0L), stopped = false)
 
-      def pause(id: Projection.Id): Task[Unit] =
-        ref.update(m => m.updated(id, m.getOrElse(id, defaultState).copy(paused = true))).unit
+      def stop(id: Projection.Id): Task[Unit] =
+        ref.update(m => m.updated(id, m.getOrElse(id, defaultState).copy(stopped = true))).unit
 
       def resume(id: Projection.Id): Task[Unit] =
-        ref.update(m => m.updated(id, m.getOrElse(id, defaultState).copy(paused = false))).unit
+        ref.update(m => m.updated(id, m.getOrElse(id, defaultState).copy(stopped = false))).unit
 
-      def isPaused(id: Projection.Id): Task[Boolean] =
-        ref.get.map(_.get(id).exists(_.paused))
+      def isStopped(id: Projection.Id): Task[Boolean] =
+        ref.get.map(_.get(id).exists(_.stopped))
 
       def offset(id: Projection.Id): Task[Option[Version]] =
         ref.get.map(_.get(id).map(_.offset))

--- a/projection/src/main/scala/com/github/aris/projection/ProjectionManagementStore.scala
+++ b/projection/src/main/scala/com/github/aris/projection/ProjectionManagementStore.scala
@@ -1,0 +1,43 @@
+package com.github
+package aris
+package projection
+
+import zio.*
+
+trait ProjectionManagementStore {
+  def pause(id: Projection.Id): Task[Unit]
+  def resume(id: Projection.Id): Task[Unit]
+  def isPaused(id: Projection.Id): Task[Boolean]
+  def offset(id: Projection.Id): Task[Option[Version]]
+  def updateOffset(id: Projection.Id, version: Version): Task[Unit]
+}
+
+object ProjectionManagementStore {
+  final case class State(offset: Version, paused: Boolean)
+
+  object memory {
+    def live(): ZLayer[Any, Nothing, ProjectionManagementStore] =
+      ZLayer.fromZIO(Ref.make(Map.empty[Projection.Id, State]).map(new MemoryProjectionManagementStore(_)))
+
+    class MemoryProjectionManagementStore(ref: Ref[Map[Projection.Id, State]]) extends ProjectionManagementStore {
+      private val defaultState = State(Version.wrap(0L), paused = false)
+
+      def pause(id: Projection.Id): Task[Unit] =
+        ref.update(m => m.updated(id, m.getOrElse(id, defaultState).copy(paused = true))).unit
+
+      def resume(id: Projection.Id): Task[Unit] =
+        ref.update(m => m.updated(id, m.getOrElse(id, defaultState).copy(paused = false))).unit
+
+      def isPaused(id: Projection.Id): Task[Boolean] =
+        ref.get.map(_.get(id).exists(_.paused))
+
+      def offset(id: Projection.Id): Task[Option[Version]] =
+        ref.get.map(_.get(id).map(_.offset))
+
+      def updateOffset(id: Projection.Id, version: Version): Task[Unit] =
+        ref.update(m =>
+          m.updated(id, m.getOrElse(id, defaultState).copy(offset = version))
+        ).unit
+    }
+  }
+}

--- a/projection/src/main/scala/com/github/aris/projection/ProjectionObserver.scala
+++ b/projection/src/main/scala/com/github/aris/projection/ProjectionObserver.scala
@@ -6,8 +6,6 @@ import zio.*
 
 trait ProjectionObserver {
   def started(id: Projection.Id, offset: Version): UIO[Unit] = ZIO.unit
-  def paused(id: Projection.Id, offset: Version): UIO[Unit] = ZIO.unit
-  def resumed(id: Projection.Id, offset: Version): UIO[Unit] = ZIO.unit
   def offsetCommitted(id: Projection.Id, offset: Version): UIO[Unit] = ZIO.unit
   def processingError(id: Projection.Id, version: Version, cause: Throwable): UIO[Unit] = ZIO.unit
   def projectionError(id: Projection.Id, cause: Throwable): UIO[Unit] = ZIO.unit

--- a/projection/src/main/scala/com/github/aris/projection/ProjectionObserver.scala
+++ b/projection/src/main/scala/com/github/aris/projection/ProjectionObserver.scala
@@ -1,0 +1,18 @@
+package com.github
+package aris
+package projection
+
+import zio.*
+
+trait ProjectionObserver {
+  def started(id: Projection.Id, offset: Version): UIO[Unit] = ZIO.unit
+  def paused(id: Projection.Id, offset: Version): UIO[Unit] = ZIO.unit
+  def resumed(id: Projection.Id, offset: Version): UIO[Unit] = ZIO.unit
+  def offsetCommitted(id: Projection.Id, offset: Version): UIO[Unit] = ZIO.unit
+  def processingError(id: Projection.Id, version: Version, cause: Throwable): UIO[Unit] = ZIO.unit
+  def projectionError(id: Projection.Id, cause: Throwable): UIO[Unit] = ZIO.unit
+}
+
+object ProjectionObserver {
+  val empty: ProjectionObserver = new ProjectionObserver {}
+}

--- a/projection/src/main/scala/com/github/aris/projection/ProjectionStore.scala
+++ b/projection/src/main/scala/com/github/aris/projection/ProjectionStore.scala
@@ -1,0 +1,23 @@
+package com.github
+package aris
+package projection
+
+import zio.*
+
+trait ProjectionStore {
+  def read(id: Projection.Id): Task[Option[Version]]
+  def save(id: Projection.Id, version: Version): Task[Int]
+}
+
+object ProjectionStore {
+  object memory {
+    def live(): ZLayer[Any, Nothing, ProjectionStore] =
+      ZLayer.fromZIO(Ref.make(Map.empty[Projection.Id, Version]).map(new MemoryProjectionStore(_)))
+
+    class MemoryProjectionStore(ref: Ref[Map[Projection.Id, Version]]) extends ProjectionStore {
+      def read(id: Projection.Id): Task[Option[Version]] = ref.get.map(_.get(id))
+      def save(id: Projection.Id, version: Version): Task[Int] =
+        ref.update(_.updated(id, version)).as(1)
+    }
+  }
+}

--- a/projection/src/main/scala/com/github/aris/projection/RetryStrategy.scala
+++ b/projection/src/main/scala/com/github/aris/projection/RetryStrategy.scala
@@ -1,0 +1,10 @@
+package com.github
+package aris
+package projection
+
+sealed trait RetryStrategy
+object RetryStrategy {
+  case object Skip extends RetryStrategy
+  final case class RetryAndFail(times: Int) extends RetryStrategy
+  final case class RetryAndSkip(times: Int) extends RetryStrategy
+}


### PR DESCRIPTION
## Summary
- extend projection observer with error hooks
- add projection management store and API
- support retry strategies in projection execution
- track offsets and paused state via new management store
- make `Projection` a trait and move pause/resume logic to `ProjectionManagement`
- hide `AtLeastOnce` and `ExactlyOnce` implementations behind factory methods
- convert `Projection.Name` to `Projection.Id` with name and version
- add doobie-based stores for projections

## Testing
- `./sbt test:compile` *(fails: Could not download sbt-launch due to no internet)*

------
https://chatgpt.com/codex/tasks/task_e_6849658bd7588322b05e6b2af25bbc85