### PR TITLE
Add flyway migration scripts

### DIFF
--- a/db.md
+++ b/db.md
@@ -1,0 +1,35 @@
+# Database Migrations
+
+This project stores all SQL migration scripts in the `db` directory at the repository root. The scripts follow the standard [Flyway](https://flywaydb.org) naming convention.
+
+## Running Migrations
+
+1. **Download Flyway Command Line**
+
+   Grab the standalone Flyway command line package from the [Flyway downloads page](https://flywaydb.org/download). Unzip it somewhere on your machine.
+
+2. **Set Connection Parameters**
+
+   Provide the database connection details when executing Flyway. Below is an example using a PostgreSQL database:
+
+   ```bash
+   flyway \
+     -url=jdbc:postgresql://<host>:<port>/<database> \
+     -user=<user> \
+     -password=<password> \
+     -locations=filesystem:db \
+     migrate
+   ```
+
+   The `-locations` option points Flyway to the `db` folder that contains the migration scripts.
+
+3. **Migration Order**
+
+   Flyway executes scripts in lexicographical order based on their version prefix. The migrations included here are:
+
+   - `V1__event_store_schema.sql` – creates the event store tables.
+   - `V2__projection_schema.sql` – creates tables used by the projection module.
+
+   Additional scripts should continue the version sequence (e.g. `V3__...`).
+
+That's it! Running the command above will apply all pending migrations in order.

--- a/db/V1__event_store_schema.sql
+++ b/db/V1__event_store_schema.sql
@@ -1,0 +1,28 @@
+CREATE TABLE IF NOT EXISTS events (
+  version BIGINT PRIMARY KEY,
+  aggregate_id BIGINT NOT NULL,
+  discriminator TEXT NOT NULL,
+  namespace INT NOT NULL,
+  payload BYTEA NOT NULL,
+  timestamp BIGINT NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_events_discriminator ON events(discriminator);
+CREATE INDEX IF NOT EXISTS idx_events_aggregate_id ON events(aggregate_id);
+CREATE INDEX IF NOT EXISTS idx_events_discriminator_namespace ON events(discriminator, namespace);
+CREATE INDEX IF NOT EXISTS idx_events_aggregate_disc_ns ON events(aggregate_id, discriminator, namespace);
+CREATE INDEX IF NOT EXISTS idx_events_timestamp ON events(timestamp);
+
+CREATE TABLE IF NOT EXISTS tags (
+  version BIGINT NOT NULL,
+  tag TEXT NOT NULL,
+  PRIMARY KEY(version, tag),
+  FOREIGN KEY(version) REFERENCES events(version) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS idx_tags_tag ON tags(tag);
+
+CREATE TABLE IF NOT EXISTS snapshots (
+  aggregate_id BIGINT PRIMARY KEY,
+  version BIGINT NOT NULL
+);

--- a/db/V2__projection_schema.sql
+++ b/db/V2__projection_schema.sql
@@ -1,0 +1,18 @@
+CREATE TABLE IF NOT EXISTS projection_offset (
+  name TEXT NOT NULL,
+  version TEXT NOT NULL,
+  namespace INT NOT NULL,
+  offset BIGINT NOT NULL,
+  PRIMARY KEY(name, version, namespace)
+);
+
+CREATE TABLE IF NOT EXISTS projection_management (
+  name TEXT NOT NULL,
+  version TEXT NOT NULL,
+  namespace INT NOT NULL,
+  stopped BOOLEAN NOT NULL,
+  PRIMARY KEY(name, version, namespace)
+);
+
+CREATE INDEX IF NOT EXISTS idx_projection_offset_namespace ON projection_offset(namespace);
+CREATE INDEX IF NOT EXISTS idx_projection_management_namespace ON projection_management(namespace);


### PR DESCRIPTION
## Summary
- create a `db` directory with flyway-compatible SQL scripts
- document how to run migrations using Flyway CLI

## Testing
- `sbt test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ee6d7fc148322bf55fc93455ce3c5